### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   },
   "homepage": "https://github.com/react-native-component/react-native-smart-loading-spinner-overlay#readme",
   "dependencies": {
+    "prop-types": "^15.6.0",
     "react-native-smart-timer-enhance": "^1.0.2"
   }
 }


### PR DESCRIPTION
react.PropTypes 已经不再被0.5.0后的 rn 版本支持, 强制性的!