### PR TITLE
Update LoadingSpinnerOverlay.js

### DIFF
--- a/LoadingSpinnerOverlay.js
+++ b/LoadingSpinnerOverlay.js
@@ -5,10 +5,7 @@
  * Copyright (c) 2016 react-native-component <moonsunfall@aliyun.com>
  */
 
-import React, {
-    Component,
-    PropTypes,
-} from 'react'
+import React, {Component} from 'react'
 import {
     View,
     Modal,
@@ -20,6 +17,7 @@ import {
     ActivityIndicatorIOS,
     ProgressBarAndroid,
 } from 'react-native'
+import PropTypes from 'prop-types'
 
 import TimerEnhance from 'react-native-smart-timer-enhance'
 


### PR DESCRIPTION
React.PropTypes 已不被新版本支持, 强制性的报错