### PR TITLE
replace Toast with LoadingSpinnerOverlay in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ import {
 
 import Button from 'react-native-smart-button'
 import TimerEnhance from 'react-native-smart-timer-enhance'
-import Toast from 'react-native-smart-loading-spinner-overlay'
+import LoadingSpinnerOverlay from 'react-native-smart-loading-spinner-overlay'
 
 class LoadingSpinnerOverLayDemo extends Component {
 


### PR DESCRIPTION
I think there is a mistake in the README, Toast is declared but is never used, and LoadingSpinnerOverlay is being used but is not declared so I think Toast is referring to `LoadingSpinnerOverlay`